### PR TITLE
Update imagelazyloading.php

### DIFF
--- a/imagelazyloading.php
+++ b/imagelazyloading.php
@@ -37,7 +37,7 @@ class PlgContentImageLazyloading extends CMSPlugin
 		}
 
 		// Check and add the loading attribute for images
-		if ($this->params->get('enabled_image', false) && preg_match_all('/<img\s[^>]+>/', $row->text, $imgMatches))
+		if ($this->params->get('enabled_image', true) && preg_match_all('/<img\s[^>]+>/', $row->text, $imgMatches))
 		{
 			foreach ($imgMatches[0] as $image)
 			{


### PR DESCRIPTION
The default value must be true, otherwise the plugin will no longer work after an update. Because ''loading="lazy" is not loaded.

See also the manifest file imagelazeloading.xml (default = 1 for enabled_image)